### PR TITLE
Updated git clone commands to pull from kytos-ng

### DIFF
--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -16,7 +16,7 @@ First you need to clone *kytos* repository:
 
 .. code-block:: shell
 
-   $ git clone https://github.com/kytos/kytos.git
+   $ git clone https://github.com/kytos-ng/kytos.git
 
 After cloning, the installation process is done by standard `setuptools`
 install procedure:

--- a/tutorials/napps/development_environment_setup.rst
+++ b/tutorials/napps/development_environment_setup.rst
@@ -133,7 +133,7 @@ kytos-utils and kytos projects locally.
 .. code-block:: shell
 
   for repo in python-openflow kytos-utils kytos; do
-    git clone https://github.com/kytos/${repo}
+    git clone https://github.com/kytos-ng/"${repo}"
   done
 
 After cloning, the Kytos installation process is done running setuptools installation
@@ -142,7 +142,7 @@ procedure for each cloned repository, in order. Below we execute its commands.
 .. code-block:: shell
 
     for repo in python-openflow kytos-utils kytos; do
-      cd ${repo}
+      cd "${repo}"
       python3 setup.py develop
       cd ..
     done
@@ -158,7 +158,7 @@ and run:
 .. code-block:: console
 
   $ source test42/bin/activate
-  $ git clone https://github.com/kytos/storehouse
+  $ git clone https://github.com/kytos-ng/storehouse
   $ cd storehouse
   $ pip install -r requirements/dev.txt
   $ python3 setup.py develop


### PR DESCRIPTION
Fixes #3

- Updated git clone commands to pull from kytos-ng, just so new contributors don't get confused 
- Updated shell commands to escape a variable to be compatible with zsh too