### PR TITLE
docs: updated dev env setup with current pinned pip related deps

### DIFF
--- a/tutorials/napps/development_environment_setup.rst
+++ b/tutorials/napps/development_environment_setup.rst
@@ -107,12 +107,12 @@ If you want to use an existing environment you can use the following command:
   source test42/bin/activate
 
 After that, your console prompt will show the activated virtualenv name between
-parenthesis. Now, update the *pip* package that is already installed in the
-virtualenv, with setuptools and wheel as well:
+parenthesis. Now, update the ``pip`` package that is already installed in the
+virtualenv, with ``setuptools`` and ``wheel`` as well to the following versions:
 
 .. code-block:: console
 
-  (test42) pip install --upgrade pip setuptools wheel
+  (test42) pip install pip==24.3.1 setuptools==75.6.0 wheel==0.45.1
 
 Having this packages updated is important to avoid some conflicts. For more
 imformation check out `Python packaging documentation on setup.py <https://packaging.python.org/en/latest/discussions/setup-py-deprecated/>`_
@@ -171,6 +171,21 @@ later in the following tutorials.
 .. NOTE:: Currently, NApps should be installed by cloning the source code and installing through the setup.py file
 
 Currently, flow_manager and topology require MongoDB to be setup. Before installing the Napps, follow the instructions below
+
+Running Unit Tests
+==================
+
+Python unit tests are run with *tox*, which will create its own virtual venv, isolating the testing libraries dependencies. If you need to run unit tests to validate code changes, first install tox and virtualenv with the following versions. You can still use the same ``test42`` venv to install ``tox``, having it in the same venv can be convenient, it's up to you:
+
+.. code-block:: console
+
+  (test42) pip install tox==4.13.0 virtualenv==20.25.1
+
+Once installed, to run the tests and linters:
+
+.. code-block:: console
+
+  (test42) tox
 
 How to use with MongoDB
 =======================


### PR DESCRIPTION


Closes https://github.com/kytos-ng/kytos/issues/584

### Summary

See the updated docs. From now on for testing, these are the only pip related supported dependencies (other versions might work but no guarantees from our core team). The final solution will be addressed on https://github.com/kytos-ng/kytos/issues/585, but this ensures that it won't break anymore until we lift these pinned dependencies. 

```
tox==4.13.0 virtualenv==20.25.1 pip==24.3.1 setuptools==75.6.0 wheel==0.45.1
```

### Local Tests

- Followed the guide locally from scratch with `kytos` and `mef_eline` and ran `tox`:

```
lint: recreate env because env type changed from {'name': 'coverage', 'type': 'VirtualEnvRunner'} to {'name': 'lint', 'type': 'VirtualEnvRunner'}
lint: remove tox env folder /tmp/ky5/mef_eline/.tox/py311
lint: install_deps> python -I -m pip install -r requirements/dev.in
lint: commands[0]> python3 setup.py lint
running lint
Yala is running. It may take several seconds...
INFO: Finished isort
INFO: Finished pycodestyle
INFO: Finished pylint
[isort] Skipped 4 files
:) No issues found.
No linter error found.
  coverage: OK (72.34=setup[29.68]+cmd[42.66] seconds)
  lint: OK (44.27=setup[30.00]+cmd[14.27] seconds)
  congratulations :) (116.65 seconds)
```

- Ran scrutinizer CI on [mef_eline](https://scrutinizer-ci.com/g/kytos-ng/mef_eline/inspections/9812e2ed-e8c3-4953-ae57-949f9722d5d7/log)
- Ran scrutinizer CI on [kytos](https://scrutinizer-ci.com/g/kytos-ng/kytos/inspections/a90efed4-e31c-4410-bfa8-762ad24fbf96/log)


